### PR TITLE
add set request level for log function

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -10,6 +10,11 @@ class Logger implements LoggerInterface
 {
 
     /**
+     * All level
+     */
+    const ALL = -2147483647;
+
+    /**
      * Detailed debug information
      */
     const DEBUG = 100;
@@ -60,6 +65,11 @@ class Logger implements LoggerInterface
     const EMERGENCY = 600;
 
     /**
+     * request Level limit
+     */
+    static $RequestLevel =  self::ALL;
+
+    /**
      * Monolog API version
      *
      * This is only bumped when API breaks are done and should
@@ -86,6 +96,14 @@ class Logger implements LoggerInterface
         self::ALERT => 'ALERT',
         self::EMERGENCY => 'EMERGENCY',
     ];
+
+    /**
+     * set request level for seaslog
+     * @param int $level
+     */
+    public function setRequestLevel( $level = self::ALL ) {
+        self::$RequestLevel = $level;
+    }
 
     /**
      * @param string $message
@@ -166,7 +184,36 @@ class Logger implements LoggerInterface
      */
     public function log($level, $message, array $context = array())
     {
-        SeasLog::log($level, $message, $context);
+        if ( ( int ) $level < self::$RequestLevel ) return ;
+
+        switch($level){
+            case self::EMERGENCY:
+                SeasLog::emergency($message, $context);
+                break;
+            case self::ALERT:
+                SeasLog::alert($message, $context);
+                break;
+            case self::CRITICAL:
+                SeasLog::critical($message, $context);
+                break;
+            case self::ERROR:
+                SeasLog::error($message, $context);
+                break;
+            case self::WARNING:
+                SeasLog::warning($message, $context);
+                break;
+            case self::NOTICE:
+                SeasLog::notice($message, $context);
+                break;
+            case self::INFO:
+                SeasLog::info($message, $context);
+                break;
+            case self::DEBUG:
+                SeasLog::debug($message, $context);
+                break;
+            default:
+                break;
+        }
     }
 
     /**

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -66,6 +66,20 @@ class LoggerTest extends TestCase
     public function testLog() {
         $logger = $this->init();
         $this->assertInstanceOf(Logger::class, $logger);
-        $logger->log('debug','[SeasLog Test]', ['level' => 'log']);
+        $logger->log(Logger::DEBUG,'[SeasLog Test]', ['level' => 'log']);
+    }
+
+    public function testRequestLevel() {
+        $logger = $this->init();
+        $this->assertInstanceOf(Logger::class, $logger);
+        $logger->setRequestLevel(Logger::ERROR);
+        $logger->log(Logger::DEBUG,'[SeasLog Test]', ['level' => 'DEBUG']);
+        $logger->log(Logger::WARNING,'[SeasLog Test]', ['level' => 'WARNING']);
+        $logger->log(Logger::ERROR,'[SeasLog Test]', ['level' => 'ERROR']);
+        $logger->log(Logger::INFO,'[SeasLog Test]', ['level' => 'INFO']);
+        $logger->log(Logger::CRITICAL,'[SeasLog Test]', ['level' => 'CRITICAL']);
+        $logger->log(Logger::EMERGENCY,'[SeasLog Test]', ['level' => 'EMERGENCY']);
+        $logger->log(Logger::NOTICE,'[SeasLog Test]', ['level' => 'NOTICE']);
     }
 }
+


### PR DESCRIPTION
在使用log方法记录日志的过程中，可能会记录多种级别的日志，开发环境中可能需要全部写入日志，但是在生产环境中，可能就会限制日志级别的输出，待需要调试的时候，在进行降级开启，方便调试与日志管理。